### PR TITLE
Introduce next-placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
-# next-blurhash
+# next-placeholder
 
-> **Create [BlurHash][blurhash] strings in Next.js getStaticProps 🖼**
+> **Roll-you-own placeholders for Next.js images 🖼**
 >
 > Designed to work with [Next.js 10 Image Optimization][next/image]
 >
-> [See the demo][demo]
+> ---
+>
+> Choose-your-own approach:  
+> [**Base64**](#base64) or [**BlurHash**](#blurhash)
+>
+> ---
+>
+> [**See the demo ↗** ][demo]
 
-![NPM Version](https://badgen.net/npm/v/next-blurhash)
-![Types Included](https://badgen.net/npm/types/next-blurhash)
-![License](https://badgen.net/github/license/joe-bell/next-blurhash)
-![NPM Downloads](https://badgen.net/npm/dm/next-blurhash)
+![NPM Version](https://badgen.net/npm/v/next-placeholder)
+![Types Included](https://badgen.net/npm/types/next-placeholder)
+![License](https://badgen.net/github/license/joe-bell/next-placeholder)
+![NPM Downloads](https://badgen.net/npm/dm/next-placeholder)
 
 ## Table of Contents
 
@@ -18,7 +25,12 @@
 
 ## Setup
 
-In this example, we're going to create a [BlurHash][blurhash] string for a single image inside a Next.js [Page](https://nextjs.org/docs/basic-features/pages).
+- [Base64](#base64)
+- [BlurHash](#blurhash)
+
+### BlurHash
+
+In this example, we're going to use the additional `next-blurhash` package to create a [BlurHash][blurhash] string for a single image inside a Next.js [Page](https://nextjs.org/docs/basic-features/pages).
 
 We'll then use [`react-blurhash`][react-blurhash] to render the string to a canvas, to sit underneath our [`Image`][next/image] whilst it's loading.
 
@@ -38,7 +50,7 @@ We'll then use [`react-blurhash`][react-blurhash] to render the string to a canv
 
 3. Create a new page (or add to an existing page), and add the following:
 
-   1. Call `getStaticBlurhash()` inside `getStaticProps()` with your image's path **without the `public` prefix**.
+   1. Call `getBlurhash()` inside `getStaticProps()` with your image's path **without the `public` prefix**.
 
       This will return the [BlurHash][blurhash] string as a static prop (which will be decoded to dimensions of **32×32**).
 
@@ -50,12 +62,12 @@ We'll then use [`react-blurhash`][react-blurhash] to render the string to a canv
    // pages/index.jsx
    import * as React from "react";
    import Image from "next/image";
-   import { getStaticBlurhash } from "next-blurhash";
+   import { getBlurhash } from "next-blurhash";
    import { BlurhashCanvas } from "react-blurhash";
 
    export const getStaticProps: GetStaticProps = async () => {
      const imgSrc = "/keila-joa.jpg";
-     const imgHash = await getStaticBlurhash(imgSrc);
+     const imgHash = await getBlurhash(imgSrc);
 
      return {
        props: {
@@ -73,7 +85,7 @@ We'll then use [`react-blurhash`][react-blurhash] to render the string to a canv
            <BlurhashCanvas
              // Your generated Blurhash string
              hash={imgHash}
-             // getStaticBlurhash **always** returns 32×32 dimensions
+             // getBlurhash **always** returns 32×32 dimensions
              width={32}
              height={32}
              punch={1}
@@ -101,13 +113,98 @@ We'll then use [`react-blurhash`][react-blurhash] to render the string to a canv
 
    You should expect to see the [BlurHash][blurhash] canvas first, then the image optimized by Next.js
 
+### Base64
+
+In this example, we're going to use the base `next-placeholder` package to create a Base64 string for a single image inside a Next.js [Page](https://nextjs.org/docs/basic-features/pages).
+
+We'll then apply the string to an `<img>` element (hidden from screen-readers) and position underneath our [`Image`][next/image] whilst it's loading.
+
+> [**See the demo**][demo] for a live example.
+
+1. Add the package to your existing Next.js project:
+
+   ```sh
+   npm i next-placeholder
+   ```
+
+2. Add your chosen image to the [`public`](https://nextjs.org/docs/basic-features/static-file-serving) directory.
+
+   In this case, our image is `public/keila-joa.jpg` (to match the [demo][demo])
+
+   > In it's current state, `next-placeholder` only supports [local images](#what-about-remote-images).
+
+3. Create a new page (or add to an existing page), and add the following:
+
+   1. Call `getBase64()` inside `getStaticProps()` with your image's path **without the `public` prefix**. This will return the Base64 string as a static prop.
+
+   2. Add custom styles to position (and blur) the placeholder `img` underneath Next.js' `Image` whilst it loads.
+
+   An `aria-hidden` ensures the content is hidden from screen-readers.
+
+   ```jsx
+   // pages/index.jsx
+   import * as React from "react";
+   import Image from "next/image";
+   import { getBase64 } from "next-placeholder";
+
+   export const getStaticProps: GetStaticProps = async () => {
+     const imgSrc = "/keila-joa.jpg";
+     const imgBase64 = await getBase64(imgSrc);
+
+     return {
+       props: {
+         imgBase64,
+         imgSrc,
+       },
+     };
+   };
+
+   function Index({ imgBase64, imgSrc }) {
+     return (
+       <main>
+         <div style={{ position: "relative", overflow: "hidden" }}>
+           {/* Our placeholder image */}
+           <img
+             aria-hidden="true"
+             alt=""
+             src={imgBase64}
+             style={{
+               position: "absolute",
+               top: 0,
+               left: 0,
+               right: 0,
+               bottom: 0,
+               width: "100%",
+               height: "100%",
+               /* Adjust the content to fit */
+               objectFit: "cover",
+               objectPosition: "center",
+               /* Blur the image and scale to avoid transparent corners */
+               filter: "blur(2rem)",
+               transform: "scale(1.2)",
+             }}
+           />
+           {/* Your image, optimized by next/image */}
+           <Image src={imgSrc} width={4032} height={3024} />
+         </div>
+       </main>
+     );
+   }
+
+   export default Index;
+   ```
+
+4. [Run your Next.js app](https://nextjs.org/docs/api-reference/cli#build) to see the results in action!
+
+   You should expect to see the placeholder first, then the image optimized by Next.js
+
 ## FAQs
 
 - [What about remote images?](#what-about-remote-images)
 
 ### What about remote images?
 
-In it's current state, `next-blurhash` only supports local images (added to `public`). PRs to add support for remote images are welcomed ❤️.
+In it's current state, `next-placeholder` only supports local images (added to `public`). PRs to add support for remote images are welcomed ❤️.
 
 [blurhash]: https://blurha.sh/
 [react-blurhash]: https://github.com/woltapp/react-blurhash

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "next": "10.0.0",
     "next-blurhash": "^0.1.0",
+    "next-placeholder": "^0.1.0",
     "react": "16.13.1",
     "react-blurhash": "0.1.3",
     "react-dom": "16.13.1"

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -8,7 +8,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "clean": "rimraf .next"
+    "clean": "rimraf .next",
+    "build:vercel": "yarn workspace next-placeholder build && yarn workspace next-blurhash build && yarn workspace demo build"
   },
   "dependencies": {
     "next": "10.0.0",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "start": "next start",
     "clean": "rimraf .next",
-    "build:vercel": "yarn workspace next-placeholder build && yarn workspace next-blurhash build && yarn workspace demo build"
+    "build:vercel": "yarn workspace next-placeholder build && yarn workspace next-blurhash build && yarn build"
   },
   "dependencies": {
     "next": "10.0.0",

--- a/packages/demo/pages/index.tsx
+++ b/packages/demo/pages/index.tsx
@@ -1,42 +1,91 @@
 import * as React from "react";
 import { GetStaticProps } from "next";
-import { getStaticBlurhash } from "next-blurhash";
+import { getBase64 } from "next-placeholder";
+import { getBlurhash } from "next-blurhash";
 import { BlurhashCanvas } from "react-blurhash";
 import Image from "next/image";
 
-type DemoProps = Record<"imgHash" | "imgSrc", string>;
+type DemoProps = {
+  img: Record<"alt" | "href" | "title" | "base64" | "hash" | "src", string>;
+};
 
 export const getStaticProps: GetStaticProps<DemoProps> = async () => {
-  const imgSrc = "/keila-joa.jpg";
-  const imgHash = await getStaticBlurhash(imgSrc);
+  const src = "/keila-joa.jpg";
+  const base64 = await getBase64(src);
+  const hash = await getBlurhash(src);
 
   return {
     props: {
-      imgHash,
-      imgSrc,
+      img: {
+        alt: "Keila Joa, Estonia.",
+        href: "https://instagram.com/joebell",
+        src,
+        base64,
+        hash,
+        title: "© Joe Bell",
+      },
     },
   };
 };
 
-const Index: React.FC<DemoProps> = ({ imgHash, imgSrc }) => (
-  <main className="max-w-4xl mx-auto px-4 mt-6 pb-6 text-gray-800">
-    <h1 className="font-bold text-4xl text-center">next-blurhash</h1>
+const Index: React.FC<DemoProps> = ({ img }) => (
+  <main className=" max-w-4xl mx-auto px-4 mt-6 pb-20 text-gray-800">
+    <h1 className="font-bold text-4xl">next-placeholder</h1>
 
-    <section className="text-center mx-auto mt-2 pb-6">
+    <p className="mt-3">
       <a
-        className="text-blue-700 hover:underline"
+        className="text-xl text-blue-700 hover:underline"
         href="https://github.com/joe-bell/next-blurhash"
       >
         See the README
       </a>
-    </section>
+    </p>
 
-    <a href="https://instagram.com/joebell">
+    <h3 className="font-mono text-2xl mt-6">getBase64(&lt;image-path&gt;)</h3>
+
+    <a className="block mt-4" href={img.href}>
+      {/* For the sake of legibility, this example uses inline styles, but don't
+      do this in production */}
+      <div style={{ position: "relative", overflow: "hidden" }}>
+        <img
+          aria-hidden="true"
+          alt=""
+          src={img.base64}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+            filter: "blur(2rem)",
+            transform: "scale(1.2)",
+          }}
+        />
+        <Image
+          alt={img.alt}
+          title={img.title}
+          src={img.src}
+          width={4032}
+          height={3024}
+        />
+      </div>
+    </a>
+
+    <hr className="mt-8" />
+
+    <h2 className="font-bold text-3xl mt-6">next-blurhash</h2>
+    <h3 className="font-mono text-2xl mt-4">getBlurhash(&lt;image-path&gt;)</h3>
+
+    <a className="block mt-4" href={img.href}>
       {/* For the sake of legibility, this example uses inline styles, but don't
       do this in production */}
       <div style={{ position: "relative" }}>
         <BlurhashCanvas
-          hash={imgHash}
+          hash={img.hash}
           width={32}
           height={32}
           punch={1}
@@ -50,7 +99,13 @@ const Index: React.FC<DemoProps> = ({ imgHash, imgSrc }) => (
             height: "100%",
           }}
         />
-        <Image src={imgSrc} width={4032} height={3024} />
+        <Image
+          alt={img.alt}
+          title={img.title}
+          src={img.src}
+          width={4032}
+          height={3024}
+        />
       </div>
     </a>
   </main>

--- a/packages/demo/styles/index.css
+++ b/packages/demo/styles/index.css
@@ -1,3 +1,8 @@
 @tailwind base;
+
+img {
+  color: transparent;
+}
+
 @tailwind components;
 @tailwind utilities;

--- a/packages/next-blurhash/README.md
+++ b/packages/next-blurhash/README.md
@@ -1,1 +1,1 @@
-[See main README](https://github.com/joe-bell/next-blurhash)
+[See main README](https://github.com/joe-bell/next-placeholder)

--- a/packages/next-blurhash/package.json
+++ b/packages/next-blurhash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-blurhash",
   "version": "0.1.0",
-  "description": "Create BlurHash strings in Next.js getStaticProps",
+  "description": "Roll-you-own BlurHash placeholders for Next.js images",
   "author": "Joe Bell <joe@joebell.co.uk>",
   "license": "MIT",
   "source": "src/index.ts",
@@ -19,19 +19,22 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/joe-bell/next-blurhash.git"
+    "url": "git+https://github.com/joe-bell/next-placeholder.git"
   },
   "keywords": [
     "next.js",
     "next/image",
-    "blurhash"
+    "blurhash",
+    "placeholder",
+    "next-placeholder"
   ],
   "bugs": {
-    "url": "https://github.com/joe-bell/next-blurhash/issues"
+    "url": "https://github.com/joe-bell/next-placeholder/issues"
   },
-  "homepage": "https://github.com/joe-bell/next-blurhash#readme",
+  "homepage": "https://github.com/joe-bell/next-placeholder#readme",
   "dependencies": {
-    "blurhash": "1.1.3"
+    "blurhash": "1.1.3",
+    "next-placeholder": "^0.1.0"
   },
   "devDependencies": {
     "next": "10.0.0",

--- a/packages/next-blurhash/src/index.ts
+++ b/packages/next-blurhash/src/index.ts
@@ -3,20 +3,19 @@ import fs from "fs";
 import path from "path";
 import { promisify } from "util";
 import { encode } from "blurhash";
+import { validateImagePath, NextPlaceholderImagePath } from "next-placeholder";
 
-export const getStaticBlurhash = async (imgPath: string): Promise<string> => {
-  if (imgPath.startsWith("http")) {
-    throw new Error("Sorry, remote images aren't supported just yet");
-  }
+export type NextBlurhash = string;
 
-  if (!imgPath.startsWith("/")) {
-    throw new Error(
-      `Failed to parse \"${imgPath}\", relative images must start with a leading slash`
-    );
-  }
+export interface GetBlurhash {
+  (imagePath: NextPlaceholderImagePath): Promise<NextBlurhash>;
+}
+
+export const getBlurhash: GetBlurhash = async (imagePath) => {
+  validateImagePath(imagePath);
 
   const imageFile = await promisify(fs.readFile)(
-    path.join("./public/", imgPath)
+    path.join("./public/", imagePath)
   );
 
   const transform = new Promise<string>((resolve, reject) => {

--- a/packages/next-placeholder/CHANGELOG.md
+++ b/packages/next-placeholder/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0 (2020-10-28)
+
+
+### Features
+
+* initial commit ([7da9ebf](https://github.com/joe-bell/next-blurhash/commit/7da9ebf1e60fe65a36c8615b6d4ae89be863149b))

--- a/packages/next-placeholder/README.md
+++ b/packages/next-placeholder/README.md
@@ -1,0 +1,1 @@
+[See main README](https://github.com/joe-bell/next-placeholder)

--- a/packages/next-placeholder/package.json
+++ b/packages/next-placeholder/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "next-placeholder",
+  "version": "0.1.0",
+  "description": "Roll-you-own placeholders for Next.js images",
+  "author": "Joe Bell <joe@joebell.co.uk>",
+  "license": "MIT",
+  "source": "src/index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "microbundle --no-compress --tsconfig tsconfig.json --external sharp",
+    "dev": "yarn build -- watch",
+    "clean": "rimraf {dist,.rts2*}"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/joe-bell/next-placeholder.git"
+  },
+  "keywords": [
+    "next.js",
+    "next/image",
+    "placeholder",
+    "next-placeholder"
+  ],
+  "bugs": {
+    "url": "https://github.com/joe-bell/next-placeholder/issues"
+  },
+  "homepage": "https://github.com/joe-bell/next-placeholder#readme",
+  "dependencies": {
+    "blurhash": "1.1.3"
+  },
+  "devDependencies": {
+    "next": "10.0.0"
+  },
+  "peerDependencies": {
+    "next": ">= 10.0.0"
+  }
+}

--- a/packages/next-placeholder/src/index.ts
+++ b/packages/next-placeholder/src/index.ts
@@ -1,0 +1,60 @@
+import sharp from "sharp";
+import fs from "fs";
+import path from "path";
+import { promisify } from "util";
+
+export type NextPlaceholderImagePath = string;
+export type NextPlaceholderBase64 = string;
+
+export interface ValidateImagePath {
+  (imagePath: NextPlaceholderImagePath): void;
+}
+
+export const validateImagePath: ValidateImagePath = (imagePath) => {
+  if (imagePath.startsWith("http")) {
+    throw new Error("Sorry, remote images aren't supported just yet");
+  }
+
+  if (!imagePath.startsWith("/")) {
+    throw new Error(
+      `Failed to parse \"${imagePath}\", relative images must start with a leading slash`
+    );
+  }
+};
+
+export interface GetBase64 {
+  (imagePath: NextPlaceholderImagePath): Promise<NextPlaceholderBase64>;
+}
+
+export const getBase64: GetBase64 = async (imagePath) => {
+  validateImagePath(imagePath);
+
+  const imageFile = await promisify(fs.readFile)(
+    path.join("./public/", imagePath)
+  );
+
+  const imagePathExt = imagePath.split(".").slice(-1).pop();
+  const base64Ext = { jpg: "jpeg" }[imagePathExt] || imagePathExt;
+
+  const toBase64 = (buffer) =>
+    `data:image/${base64Ext};base64,${buffer.toString("base64")}`;
+
+  const transform = new Promise<NextPlaceholderBase64>((resolve, reject) => {
+    sharp(imageFile)
+      .normalise()
+      .modulate({
+        saturation: 1.2,
+        brightness: 1,
+      })
+      .removeAlpha()
+      .resize(10, 10, { fit: "inside" })
+      .toBuffer((err, buffer) => {
+        if (err) return reject(err);
+        resolve(toBase64(buffer));
+      });
+  });
+
+  return Promise.all([imageFile, transform])
+    .then((values) => values[1])
+    .catch((error) => error);
+};

--- a/packages/next-placeholder/tsconfig.json
+++ b/packages/next-placeholder/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
This PR renames the project to `next-placeholder` to supply two methods of generating placeholders:
1. `next-blurhash` - `getStaticBlurhash()` **renamed** to `getBlurhash()`
2. `next-placeholder` - provides `getBase64` (and some more options coming soon that are purely `sharp`-based)